### PR TITLE
Removed hook 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 This plugin provides a [Fastify](https://www.fastify.io/) plugin to populate a `request.user` from 
 a JWT token (custom claims) or a webhook (response body).
 
+To use it, simply invoke the `extractUser` method on the request object, or add this hook:
+
+```js
+app.addHook('preHandler', async (request, reply) => {
+  await request.extractUser()
+})
+```
+
+If JWT valdation or the webhook call fails, the `request.user` is not set. 
+
 
 ## JWT
 It's build on top of [fastify-jwt](https://github.com/fastify/fastify-jwt) plugin, so you can use all the options available there (with the exception of `namespace`, see [below](#namespace))
@@ -14,6 +24,10 @@ app.register(fastifyUser, {
   jwt: {
     secret: <my-shared-secret>
   }
+})
+
+app.addHook('preHandler', async (request, reply) => {
+  await request.extractUser()
 })
 
 app.get('/', async function (request, reply) {

--- a/index.js
+++ b/index.js
@@ -42,7 +42,8 @@ async function fastifyUser (app, options, done) {
     })
   }
 
-  app.addHook('preHandler', async function (request, reply) {
+  const extractUser = async function () {
+    const request = this
     if (typeof request.createSession === 'function') {
       try {
       // `createSession` actually exists only if jwt or webhook are enabled
@@ -51,10 +52,11 @@ async function fastifyUser (app, options, done) {
         request.log.debug({ user: request.user }, 'logged user in')
       } catch (err) {
         request.log.error({ err })
-        throw err
       }
     }
-  })
+  }
+
+  app.decorateRequest('extractUser', extractUser)
 
   done()
 }

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ async function fastifyUser (app, options, done) {
         request.log.error({ err })
       }
     }
+    return request.user
   }
 
   app.decorateRequest('extractUser', extractUser)

--- a/test/jwt-webhook.test.js
+++ b/test/jwt-webhook.test.js
@@ -109,6 +109,10 @@ test('JWT + cookies with WebHook', async ({ pass, teardown, same, equal }) => {
     }
   })
 
+  app.addHook('preHandler', async (request, reply) => {
+    await request.extractUser()
+  })
+
   app.get('/', async function (request, reply) {
     return request.user
   })
@@ -244,6 +248,10 @@ test('Authorization both with JWT and WebHook', async ({ pass, teardown, same, e
     },
     roleKey: 'X-PLATFORMATIC-ROLE',
     anonymousRole: 'anonymous'
+  })
+
+  app.addHook('preHandler', async (request, reply) => {
+    await request.extractUser()
   })
 
   app.get('/', async function (request, reply) {

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -40,6 +40,10 @@ test('JWT verify OK using shared secret', async ({ same, teardown }) => {
     }
   })
 
+  app.addHook('preHandler', async (request, reply) => {
+    await request.extractUser()
+  })
+
   app.get('/', async function (request, reply) {
     return request.user
   })
@@ -101,6 +105,10 @@ test('JWT verify OK getting public key from jwks endpoint', async ({ same, teard
     }
   })
 
+  app.addHook('preHandler', async (request, reply) => {
+    await request.extractUser()
+  })
+
   app.get('/', async function (request, reply) {
     return request.user
   })
@@ -130,7 +138,7 @@ test('JWT verify OK getting public key from jwks endpoint', async ({ same, teard
   })
 })
 
-test('jwt verify fails if getting public key from jwks endpoint fails', async ({ pass, teardown, same, equal }) => {
+test('jwt verify fails if getting public key from jwks endpoint fails, so no user is added', async ({ pass, teardown, same, equal }) => {
   const kid = 'TEST-KID'
   const alg = 'RS256'
   // This fails
@@ -158,6 +166,10 @@ test('jwt verify fails if getting public key from jwks endpoint fails', async ({
     }
   })
 
+  app.addHook('preHandler', async (request, reply) => {
+    await request.extractUser()
+  })
+
   app.get('/', async function (request, reply) {
     return request.user
   })
@@ -180,15 +192,9 @@ test('jwt verify fails if getting public key from jwks endpoint fails', async ({
       Authorization: `Bearer ${token}`
     }
   })
-  // 500 is correct because the JWKS endpoint is failing
-  // so we cannot verify the token
-  equal(res.statusCode, 500)
-  same(res.json(), {
-    statusCode: 500,
-    code: 'JWKS_REQUEST_FAILED',
-    error: 'Internal Server Error',
-    message: 'JWKS request failed'
-  })
+
+  equal(res.statusCode, 200)
+  same(res.json(), null)
 })
 
 test('jwt verify fail if jwks succeed but kid is not found', async ({ pass, teardown, same, equal }) => {
@@ -229,6 +235,10 @@ test('jwt verify fail if jwks succeed but kid is not found', async ({ pass, tear
     }
   })
 
+  app.addHook('preHandler', async (request, reply) => {
+    await request.extractUser()
+  })
+
   app.get('/', async function (request, reply) {
     return request.user
   })
@@ -255,13 +265,8 @@ test('jwt verify fail if jwks succeed but kid is not found', async ({ pass, tear
     }
   })
 
-  equal(res.statusCode, 500)
-  same(res.json(), {
-    statusCode: 500,
-    code: 'JWK_NOT_FOUND',
-    error: 'Internal Server Error',
-    message: 'No matching JWK found in the set.'
-  })
+  equal(res.statusCode, 200)
+  same(res.json(), null)
 })
 
 test('jwt verify fails if the domain is not allowed', async ({ pass, teardown, same, equal }) => {
@@ -304,6 +309,10 @@ test('jwt verify fails if the domain is not allowed', async ({ pass, teardown, s
     }
   })
 
+  app.addHook('preHandler', async (request, reply) => {
+    await request.extractUser()
+  })
+
   app.get('/', async function (request, reply) {
     return request.user
   })
@@ -330,13 +339,8 @@ test('jwt verify fails if the domain is not allowed', async ({ pass, teardown, s
     }
   })
 
-  equal(res.statusCode, 500)
-  same(res.json(), {
-    statusCode: 500,
-    code: 'DOMAIN_NOT_ALLOWED',
-    error: 'Internal Server Error',
-    message: 'The domain is not allowed.'
-  })
+  equal(res.statusCode, 200)
+  same(res.json(), null)
 })
 
 test('jwt skips namespace in custom claims', async ({ pass, teardown, same, equal }) => {
@@ -377,6 +381,10 @@ test('jwt skips namespace in custom claims', async ({ pass, teardown, same, equa
     }
   })
 
+  app.addHook('preHandler', async (request, reply) => {
+    await request.extractUser()
+  })
+
   app.get('/', async function (request, reply) {
     return request.user
   })
@@ -415,6 +423,10 @@ test('if no jwt conf is set, no user is added', async ({ same, teardown }) => {
   teardown(app.close.bind(app))
 
   app.register(fastifyUser, {})
+
+  app.addHook('preHandler', async (request, reply) => {
+    await request.extractUser()
+  })
 
   app.get('/', async function (request, reply) {
     return request.user || {}

--- a/test/webhook.test.js
+++ b/test/webhook.test.js
@@ -54,6 +54,10 @@ test('Webhook verify OK', async ({ pass, teardown, same, equal }) => {
     }
   })
 
+  app.addHook('preHandler', async (request, reply) => {
+    await request.extractUser()
+  })
+
   app.get('/', async function (request, reply) {
     return request.user
   })
@@ -137,8 +141,12 @@ test('Non-200 status code', async ({ end, pass, teardown, same, equal }) => {
     }
   })
 
+  app.addHook('preHandler', async (request, reply) => {
+    await request.extractUser()
+  })
+
   app.get('/', async function (request, reply) {
-    return request.user
+    return request.user || {}
   })
 
   teardown(app.close.bind(app))
@@ -150,13 +158,8 @@ test('Non-200 status code', async ({ end, pass, teardown, same, equal }) => {
     method: 'GET',
     url: '/'
   })
-  equal(res.statusCode, 401)
-  same(res.json(), {
-    statusCode: 401,
-    code: 'UNAUTHORIZED',
-    error: 'Unauthorized',
-    message: 'operation not allowed'
-  })
+  equal(res.statusCode, 200)
+  same(res.json(), {})
   end()
 })
 
@@ -166,6 +169,10 @@ test('if no webhook conf is set, no user is added', async ({ same, teardown }) =
   teardown(app.close.bind(app))
 
   app.register(fastifyUser, {})
+
+  app.addHook('preHandler', async (request, reply) => {
+    request.extractUser()
+  })
 
   app.get('/', async function (request, reply) {
     return request.user || {}


### PR DESCRIPTION
Removed the `preHandler` hook and replaced with  a request decorator, users can easily add the hook if necessary (see README changes).
Also, if JWT validation or webhook call fails, do not throw: just the user is not added. 