### PR TITLE
🐛 (jwt.js): fix issue with removing leading slash from keys in user object

### DIFF
--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -19,7 +19,7 @@ module.exports = fp(async function (app, pluginOpts) {
       const userDataNoNamespace = {}
       for (const key of Object.keys(user)) {
         if (key.startsWith(namespace)) {
-          userDataNoNamespace[key.slice(namespace.length)] = user[key]
+          userDataNoNamespace[key.slice(namespace.length).replace(/^\//g, '')] = user[key]
         } else {
           userDataNoNamespace[key] = user[key]
         }


### PR DESCRIPTION
🔧 fix:
Improved the JWT namespace handling within the "fastify-user" plugin to effectively trim any leading slashes from the key. This update addresses cases where the namespace was defined without a trailing slash, which previously resulted in keys beginning with an unintended leading slash. Now, the keys are normalized by removing these leading slashes.

💡refactor: 
The logic for processing the JWT namespace has been refined to automatically remove leading slashes from keys whenever the namespace does not end with a slash. This ensures that keys are consistently formatted without any leading slashes, enhancing system reliability and preventing misrouting or path errors in applications.

🔎 Use-case:
Before this update, defining a JWT namespace without a trailing slash led to keys with a leading slash, causing potential misconfigurations in route handling or session management. With the current enhancement, the JWT namespace is sanitized by automatically trimming leading slashes, ensuring that the keys are correctly formatted for seamless integration and operation within the system. This change boosts the robustness of namespace handling, eliminating common errors related to slash misplacement. 